### PR TITLE
Add `alloc_layout_extra` feature.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 #![no_std]
 #![cfg_attr(
     not(feature = "disable"),
-    feature(alloc, dropck_eyepatch, allocator_api, fused, ptr_internals, try_reserve, nonnull_cast)
+    feature(alloc, dropck_eyepatch, allocator_api, fused, ptr_internals, try_reserve, nonnull_cast, alloc_layout_extra)
 )]
 
 #[cfg(not(feature = "disable"))]


### PR DESCRIPTION
This feature became required after recent nightly changes.

Without this change I'm getting:

```
error[E0658]: use of unstable library feature 'alloc_layout_extra' (see issue #55724)
   --> src/table.rs:663:18
    |
663 |     let hashes = Layout::array::<HashUint>(capacity)?;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(alloc_layout_extra)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'alloc_layout_extra' (see issue #55724)
   --> src/table.rs:664:17
    |
664 |     let pairs = Layout::array::<(K, V)>(capacity)?;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(alloc_layout_extra)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'alloc_layout_extra' (see issue #55724)
   --> src/table.rs:665:12
    |
665 |     hashes.extend(pairs).map(|(layout, _)| {
    |            ^^^^^^
    |
    = help: add #![feature(alloc_layout_extra)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'alloc_layout_extra' (see issue #55724)
   --> src/table.rs:673:36
    |
673 |             hashes.size() + hashes.padding_needed_for(mem::align_of::<(K, V)>()),
    |                                    ^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(alloc_layout_extra)] to the crate attributes to enable

error: aborting due to 4 previous errors

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `hashmap_core`.
```