### PR TITLE
Update to latest nightly

### DIFF
--- a/src/fnv.rs
+++ b/src/fnv.rs
@@ -28,7 +28,7 @@
 //! `HashMap` with FNV.
 //!
 //! ```rust
-//! use fnv::FnvHashMap;
+//! use hashmap_core::fnv::FnvHashMap;
 //!
 //! let mut map = FnvHashMap::default();
 //! map.insert(1, "one");
@@ -49,7 +49,7 @@
 //! with FNV.
 //!
 //! ```rust
-//! use fnv::FnvHashSet;
+//! use hashmap_core::fnv::FnvHashSet;
 //!
 //! let mut set = FnvHashSet::default();
 //! set.insert(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 #![no_std]
 #![cfg_attr(
     not(feature = "disable"),
-    feature(alloc, dropck_eyepatch, allocator_api, fused, ptr_internals, try_reserve, nonnull_cast, alloc_layout_extra)
+    feature(alloc, dropck_eyepatch, allocator_api, ptr_internals, try_reserve, alloc_layout_extra)
 )]
 
 #[cfg(not(feature = "disable"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 #![no_std]
 #![cfg_attr(
     not(feature = "disable"),
-    feature(alloc, dropck_eyepatch, allocator_api, fused, ptr_internals, try_reserve, nonnull_cast)
+    feature(alloc, dropck_eyepatch, allocator_api, fused, ptr_internals, try_reserve, nonnull_cast, alloc_layout_extra)
 )]
 
 #[cfg(not(feature = "disable"))]


### PR DESCRIPTION
I got a lot of these Errors in the latest nightly:
```
error[E0658]: use of unstable library feature 'alloc_layout_extra' (see issue #55724)                                                                                                                                                        
   --> src/table.rs:663:18                                                                                                                                                                                                                   
    |                                                                                                                                                                                                                                        
663 |     let hashes = Layout::array::<HashUint>(capacity)?;                                                                                                                                                                                 
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                             
    |                                                                                                                                                                                                                                        
    = help: add #![feature(alloc_layout_extra)] to the crate attributes to enable                                                                                                                                                            
```

So I added alloc_layout_extra to the features.
tested on `2019-01-16`